### PR TITLE
`-v`, `--verbose` arg is expected to be a boolean

### DIFF
--- a/lib/mix/tasks/task.elixir_avro.codegen.ex
+++ b/lib/mix/tasks/task.elixir_avro.codegen.ex
@@ -14,7 +14,7 @@ defmodule Mix.Tasks.ElixirAvroCodegen do
   use Mix.Task
 
   @aliases [v: :verbose, t: :target_path, s: :schemas_path, p: :prefix]
-  @strict [target_path: :string, schemas_path: :string, prefix: :string, verbose: :count]
+  @strict [target_path: :string, schemas_path: :string, prefix: :string, verbose: :verbose]
 
   @impl Mix.Task
   def run(args) do

--- a/lib/mix/tasks/task.elixir_avro.codegen.ex
+++ b/lib/mix/tasks/task.elixir_avro.codegen.ex
@@ -14,7 +14,7 @@ defmodule Mix.Tasks.ElixirAvroCodegen do
   use Mix.Task
 
   @aliases [v: :verbose, t: :target_path, s: :schemas_path, p: :prefix]
-  @strict [target_path: :string, schemas_path: :string, prefix: :string, verbose: :verbose]
+  @strict [target_path: :string, schemas_path: :string, prefix: :string, verbose: :boolean]
 
   @impl Mix.Task
   def run(args) do


### PR DESCRIPTION
Causes an error when actually used by the Codegen module, see https://github.com/dicefm/elixir-avro/blob/73138b61bc22981f494022a62c429fad4393ef81/lib/elixir_avro/codegen.ex#L54